### PR TITLE
Fix the audit

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - uses: camptocamp/initialise-gopass-summon-action@v2
+        with:
+          ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
+          github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
+
       - uses: asdf-vm/actions/install@v1
         with:
           tool_versions: python 3.8.0

--- a/c2cciutils/audit.py
+++ b/c2cciutils/audit.py
@@ -37,7 +37,7 @@ def pip(config, full_config, args):
         cve_file = os.path.join(directory, "pip-cve-ignore")
         if os.path.exists(cve_file):
             with open(cve_file) as cve_file:
-                cmd += ["--ignore=" + e.strip() for e in cve_file.read().decode().strip().split(",")]
+                cmd += ["--ignore=" + e.strip() for e in cve_file.read().strip().split(",")]
         try:
             sys.stdout.flush()
             sys.stderr.flush()
@@ -83,7 +83,7 @@ def pipenv(config, full_config, args):
         cve_file = os.path.join(directory, "pipenv-cve-ignore")
         if os.path.exists(cve_file):
             with open(cve_file) as cve_file:
-                cmd += ["--ignore=" + cve_file.read().decode().strip()]
+                cmd += ["--ignore=" + cve_file.read().strip()]
         try:
             c2cciutils.checks.error("pienv", "Audit issue, see above", file)
             sys.stdout.flush()
@@ -128,7 +128,7 @@ def npm(config, full_config, args):
         cve_file = os.path.join(directory, "npm-cve-ignore")
         if os.path.exists(cve_file):
             with open(cve_file) as cve_file:
-                cmd += ["--ignore=" + cve_file.read().decode().strip()]
+                cmd += ["--ignore=" + cve_file.read().strip()]
         try:
             sys.stdout.flush()
             sys.stderr.flush()

--- a/example-project/.github/workflows/audit.yaml
+++ b/example-project/.github/workflows/audit.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - uses: camptocamp/initialise-gopass-summon-action@v2
+        with:
+          ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
+          github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
+
       - uses: asdf-vm/actions/install@v1
         with:
           tool_versions: python 3.8.0


### PR DESCRIPTION
- The audit workflow requires gopass
- The read() of an open(filename) directly returns a string