### PR TITLE
The config can be None if we set required_workflow to None

### DIFF
--- a/c2cciutils/__init__.py
+++ b/c2cciutils/__init__.py
@@ -35,10 +35,13 @@ def merge(default_config, config):
     Deep merge the dictionaries (on dictionaries only, not on arrays).
     """
 
+    if not isinstance(default_config, dict) or not isinstance(config, dict):
+        return config
+
     for key in default_config.keys():
         if key not in config:
             config[key] = default_config[key]
-        elif isinstance(default_config[key], dict) and isinstance(config[key], dict):
+        else:
             merge(default_config[key], config[key])
     return config
 


### PR DESCRIPTION
see:
```
+ c2cciutils-checks
Traceback (most recent call last):
  File "/usr/local/bin/c2cciutils-checks", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/dist-packages/c2cciutils/scripts/checks.py", line 18, in main
    full_config = c2cciutils.get_config()
  File "/usr/local/lib/python3.8/dist-packages/c2cciutils/__init__.py", line 205, in get_config
    merge(required_workflows, config["checks"]["required_workflows"])
  File "/usr/local/lib/python3.8/dist-packages/c2cciutils/__init__.py", line 39, in merge
    if key not in config:
TypeError: argument of type 'bool' is not iterable
```