### PR TITLE
Don't follow renames

### DIFF
--- a/c2cciutils/checks.py
+++ b/c2cciutils/checks.py
@@ -147,7 +147,7 @@ def gitattribute(config, full_config, args):
             .split("\n")[-1]
             .split(" ")[0]
         )
-        subprocess.check_call(["git", "--no-pager", "diff", "--check", git_ref])
+        subprocess.check_call(["git", "--no-pager", "diff", "--no-renames", "--check", git_ref])
         return True
     except subprocess.CalledProcessError:
         error(


### PR DESCRIPTION
To avoid this warning:
warning: you may want to set your diff.renameLimit variable to at least 642 and retry the command.