### PR TITLE
Add google calendar support for publish events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Commands:
   - `c2cciutils-audit`: Do the audit, the main difference with checks is that it can change between runs on the same code.
   - `c2cciutils-publish`: Publish the project.
   - `c2cciutils-clean`: Delete Docker images on Docker Hub after corresponding branch have been deleted.
+  - `c2cciutils-google-calendar`: Tool to test the google credentials for calendar API and refresh them if needed. See `c2cciutils-google-calendar -h` for more information.
 
 
 # New project

--- a/c2cciutils/publish.py
+++ b/c2cciutils/publish.py
@@ -1,10 +1,211 @@
 # -*- coding: utf-8 -*-
-
+import argparse
 import datetime
 import glob
 import os
+import pickle
 import subprocess
 import sys
+import uuid
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+
+class GoogleCalendar:
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self):
+        self.scopes = ["https://www.googleapis.com/auth/calendar"]  # in fact it is better to hard-code this
+        self.credentials_pickle_file = os.environ.get("TMP_CREDS_FILE", "/tmp/{}.pickle".format(uuid.uuid4()))
+        self.credentials_json_file = os.environ.get(
+            "GOOGLE_CREDS_JSON_FILE", "~/google-credentials-c2cibot.json"
+        )  # used to refresh the refresh_token or to initialize the credentials the first time
+        self.calendar_id = os.environ.get(
+            "GOOGLE_CALENDAR_ID", self.gopass_get("gs/ci/google_calendar/calendarId")
+        )
+        self.token = os.environ.get("GOOGLE_TOKEN", self.gopass_get("gs/ci/google_calendar/token"))
+        self.token_uri = os.environ.get(
+            "GOOGLE_TOKEN_URI", self.gopass_get("gs/ci/google_calendar/token_uri")
+        )
+        self.refresh_token = os.environ.get(
+            "GOOGLE_REFRESH_TOKEN",
+            self.gopass_get("gs/ci/google_calendar/refresh_token"),
+        )
+        self.client_id = os.environ.get(
+            "GOOGLE_CLIENT_ID", self.gopass_get("gs/ci/google_calendar/client_id")
+        )
+        self.client_secret = os.environ.get(
+            "GOOGLE_CLIENT_SECRET",
+            self.gopass_get("gs/ci/google_calendar/client_secret"),
+        )
+
+        self.init_calendar_service()
+
+    def init_calendar_service(self):
+        self.creds = None
+        # The file token pickle stores the user's access and refresh tokens, and is
+        # created automatically when the authorization flow completes for the first
+        # time.
+        if os.path.exists(self.credentials_pickle_file):
+            with open(self.credentials_pickle_file, "rb") as token:
+                self.creds = pickle.load(token)
+        # If there are no (valid) credentials available, let the user log in.
+        if not self.creds or not self.creds.valid:
+            if self.creds and self.creds.expired and self.creds.refresh_token:
+                self.creds.refresh(Request())
+            else:
+                if self.token:
+                    self.creds = Credentials(
+                        self.token,
+                        refresh_token=self.refresh_token,
+                        token_uri=self.token_uri,
+                        client_id=self.client_id,
+                        client_secret=self.client_secret,
+                        scopes=self.scopes,
+                    )
+                else:
+                    flow = InstalledAppFlow.from_client_secrets_file(self.credentials_json_file, self.scopes)
+                    self.creds = flow.run_local_server(port=0)
+                    self.refresh_token = self.creds
+
+            # Save the credentials for the next run
+            with open(self.credentials_pickle_file, "wb") as token:
+                pickle.dump(self.creds, token)
+        self._update_creds()
+        self.service = build("calendar", "v3", credentials=self.creds)
+
+    def _update_creds(self):
+        self.client_id = self.creds.client_id
+        self.client_secret = self.creds.client_secret
+        self.token = self.creds.token
+        self.token_uri = self.creds.token_uri
+        self.refresh_token = self.creds.refresh_token
+
+    def print_all_calendars(self):
+        # list all the calendars that the user has access to.
+        # used to debug credentials
+        print("Getting list of calendars")
+        calendars_result = self.service.calendarList().list().execute()
+
+        calendars = calendars_result.get("items", [])
+
+        if not calendars:
+            print("No calendars found.")
+        for calendar in calendars:
+            summary = calendar["summary"]
+            event_id = calendar["id"]
+            primary = "Primary" if calendar.get("primary") else ""
+            print("%s\t%s\t%s" % (summary, event_id, primary))
+
+    def print_latest_events(self, time_min=None):
+        now = datetime.datetime.utcnow()
+        if not time_min:
+            time_min = datetime.datetime.utcnow() - datetime.timedelta(days=30)
+        events_result = (
+            self.service.events()
+            .list(
+                calendarId=self.calendar_id,
+                timeMin=time_min.isoformat() + "Z",
+                timeMax=now.isoformat() + "Z",
+                singleEvents=True,
+                orderBy="startTime",
+            )
+            .execute()
+        )
+        events = events_result.get("items", [])
+
+        if not events:
+            print("No upcoming events found.")
+        for event in events:
+            start = event["start"].get("dateTime", event["start"].get("date"))
+            print(start, event["summary"])
+
+    def create_event(
+        self,
+        summary="dummy/image:{}".format(datetime.datetime.now().isoformat()),
+        description="description",
+    ):
+        now = datetime.datetime.now()
+        start = now.isoformat()
+        end = (now + datetime.timedelta(minutes=15)).isoformat()
+        body = {
+            "summary": summary,
+            "description": description,
+            "start": {"dateTime": start, "timeZone": "Europe/Zurich"},
+            "end": {"dateTime": end, "timeZone": "Europe/Zurich"},
+        }
+
+        event_result = self.service.events().insert(calendarId=self.calendar_id, body=body).execute()
+        print("created event with id: {}".format(event_result["id"]))
+
+    def _print_credentials(self):
+        # UNSAFE: DO NEVER PRINT CREDENTIALS IN CI ENVIRONMENT, DEBUG ONLY!!!!
+        print(self.creds.to_json())
+
+    @staticmethod
+    def gopass_get(key):
+        try:
+            return subprocess.check_output(["gopass", "show", key]).strip().decode()
+        except subprocess.CalledProcessError:
+            return None
+
+    @staticmethod
+    def gopass_put(secret, key):
+        subprocess.check_output(["gopass", "insert", "--force", key], input=secret.encode())
+
+    def save_credentials_to_gopass(self):
+        objs_to_save = {
+            "gs/ci/google_calendar/calendarId": self.calendar_id,
+            "gs/ci/google_calendar/token": self.token,
+            "gs/ci/google_calendar/token_uri": self.token_uri,
+            "gs/ci/google_calendar/refresh_token": self.refresh_token,
+            "gs/ci/google_calendar/client_id": self.client_id,
+            "gs/ci/google_calendar/client_secret": self.client_secret,
+        }
+        for key, secret in objs_to_save.items():
+            self.gopass_put(secret, key)
+
+    def __del__(self):
+        if os.path.exists(self.credentials_pickle_file):
+            os.remove(self.credentials_pickle_file)
+
+
+def main_calendar() -> None:
+    parser = argparse.ArgumentParser(
+        description="Interact with google API for the docker publishing calendar"
+    )
+    parser.add_argument(
+        "--refresh-gopass-credentials",
+        action="store_true",
+        help="Refresh the credentials in gopass using google API",
+    )
+    parser.add_argument(
+        "--show-events-since",
+        help="show the calendar events since a date in 'YYYY-mm-dd' format",
+        type=lambda s: datetime.datetime.strptime(s, "%Y-%m-%d"),
+    )
+    parser.add_argument(
+        "--create-test-event",
+        action="store_true",
+        help="Create a dummy event to check that the calendar settings are correct",
+    )
+    args = parser.parse_args()
+
+    if args.show_events_since or args.refresh_gopass_credentials or args.create_test_event:
+        google_calendar = GoogleCalendar()
+    else:
+        parser.print_help()
+
+    if args.show_events_since:
+        google_calendar.print_latest_events(args.show_events_since)
+
+    if args.refresh_gopass_credentials:
+        google_calendar.save_credentials_to_gopass()
+
+    if args.create_test_event:
+        google_calendar.create_event()
 
 
 def pip(package, version, version_type, publish):

--- a/c2cciutils/scripts/publish.py
+++ b/c2cciutils/scripts/publish.py
@@ -149,7 +149,7 @@ def main() -> None:
                             success &= c2cciutils.publish.docker(conf, name, image_conf, tag_src, tag_dst)
                 if version_type in ["version_branch", "version_tag", "rebuild"]:
                     summary = "{}:{}".format(image_conf["name"], tag_dst)
-                    description = "Published on: {}".format(", ".join(docker_config["repository"]))
+                    description = "Published on: {}".format(", ".join(docker_config["repository"].keys()))
                     google_calendar.create_event(summary, description)
 
     if not success:

--- a/c2cciutils/scripts/publish.py
+++ b/c2cciutils/scripts/publish.py
@@ -7,6 +7,7 @@ import re
 import sys
 
 import c2cciutils.publish
+from c2cciutils.publish import GoogleCalendar
 
 
 def match(tpe, base_re):
@@ -130,6 +131,7 @@ def main() -> None:
 
     docker_config = config.get("publish", {}).get("docker", {})
 
+    google_calendar = GoogleCalendar()
     for image_conf in docker_config.get("images", []):
         if image_conf.get("group", "") == args.group:
             for tag_config in image_conf.get("tags", []):
@@ -145,6 +147,12 @@ def main() -> None:
                             )
                         else:
                             success &= c2cciutils.publish.docker(conf, name, image_conf, tag_src, tag_dst)
+                if version_type in ["version_branch", "version_tag", "rebuild"]:
+                    summary = "{}:{}".format(image_conf["name"], tag_dst)
+                    description = "Published on: {}".format(
+                        ", ".join([e["name"] for e in docker_config["repository"]])
+                    )
+                    google_calendar.create_event(summary, description)
 
     if not success:
         sys.exit(1)

--- a/c2cciutils/scripts/publish.py
+++ b/c2cciutils/scripts/publish.py
@@ -149,9 +149,7 @@ def main() -> None:
                             success &= c2cciutils.publish.docker(conf, name, image_conf, tag_src, tag_dst)
                 if version_type in ["version_branch", "version_tag", "rebuild"]:
                     summary = "{}:{}".format(image_conf["name"], tag_dst)
-                    description = "Published on: {}".format(
-                        ", ".join([e for e in docker_config["repository"]])
-                    )
+                    description = "Published on: {}".format(", ".join(docker_config["repository"]))
                     google_calendar.create_event(summary, description)
 
     if not success:

--- a/c2cciutils/scripts/publish.py
+++ b/c2cciutils/scripts/publish.py
@@ -150,7 +150,7 @@ def main() -> None:
                 if version_type in ["version_branch", "version_tag", "rebuild"]:
                     summary = "{}:{}".format(image_conf["name"], tag_dst)
                     description = "Published on: {}".format(
-                        ", ".join([e["name"] for e in docker_config["repository"]])
+                        ", ".join([e for e in docker_config["repository"]])
                     )
                     google_calendar.create_event(summary, description)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ click==7.1.2
 isort==5.7.0
 twine==3.3.0
 codespell==2.0.0
+google-api-python-client==1.12.8
+google-auth-httplib2==0.0.4
+google-auth-oauthlib==0.4.2

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "c2cciutils-audit = c2cciutils.scripts.audit:main",
             "c2cciutils-publish = c2cciutils.scripts.publish:main",
             "c2cciutils-clean = c2cciutils.scripts.clean:main",
+            "c2cciutils-google-calendar = c2cciutils.publish:main_calendar",
         ],
     },
     package_data={"c2cciutils": ["*.graphql"]},


### PR DESCRIPTION
This PR adds the support of google calendar. When an image is successfully published, it will add an event in a dedicated google calendar (see credentials and ID in gopass).