### PR TITLE
Force install resent version of httplib2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+httplib2==0.18.1
 safety==1.10.1
 Markdown==3.3.3
 markdown-table


### PR DESCRIPTION
Apparently there are some incompatibilities issue with launchpadlib:
```
ERROR: launchpadlib 1.10.13 requires testresources, which is not installed.
```