### PR TITLE
Fix None Type

### DIFF
--- a/c2cciutils/__init__.py
+++ b/c2cciutils/__init__.py
@@ -731,9 +731,8 @@ def get_based_on_master(
     branches_re = compile_re(config["version"].get("branch_to_version_re", []))
     if does_match(current_branch, branches_re):
         return False
-    commits_json = graphql("commits.graphql", {"name": repo[1], "owner": repo[0], "branch": current_branch})[
-        "repository"
-    ]["ref"]["target"]["history"]["nodes"]
+    commits_json = graphql("commits.graphql", {"name": repo[1], "owner": repo[0], "branch": current_branch}).get(
+        "repository", {}).get("ref", {}).get("target", {}).get("history", {}).get("nodes", [])
     branches_json = [
         branch
         for branch in (


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/runner/.local/bin/c2cciutils-checks", line 8, in <module>
    sys.exit(main())
  File "/home/runner/.local/lib/python3.8/site-packages/c2cciutils/scripts/checks.py", line 25, in main
    full_config = c2cciutils.get_config(args.branch)
  File "/home/runner/.local/lib/python3.8/site-packages/c2cciutils/__init__.py", line 145, in get_config
    based_on_master = get_based_on_master(repo, branch, master_branch, config) if credentials else False
  File "/home/runner/.local/lib/python3.8/site-packages/c2cciutils/__init__.py", line 734, in get_based_on_master
    commits_json = graphql("commits.graphql", {"name": repo[1], "owner": repo[0], "branch": current_branch})[
TypeError: 'NoneType' object is not subscriptable