### PR TITLE
Use more dictionaries, ignore ro

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-All the code in this library is provided under this licence:
+All the code in this library is provided under this license:
 
     Copyright (c) 2020, Camptocamp SA
     All rights reserved.

--- a/c2cciutils/checks.py
+++ b/c2cciutils/checks.py
@@ -863,6 +863,11 @@ def codespell(
             cmd.append("--write-changes")
         if os.path.exists("spell-ignore-words.txt"):
             cmd.append("--ignore-words=spell-ignore-words.txt")
+        dictionaries = config.get(
+            "internal_dictionaries", c2cciutils.configuration.CODESPELL_DICTIONARIES_DEFAULT
+        )
+        if dictionaries:
+            cmd.append("--builtin=" + ",".join(dictionaries))
         cmd += config.get("arguments", c2cciutils.configuration.CODESPELL_ARGUMENTS_DEFAULT)
         cmd.append("--")
         ignore_res = [

--- a/c2cciutils/configuration.py
+++ b/c2cciutils/configuration.py
@@ -144,7 +144,11 @@ BLACK_CONFIGURATION_PROPERTIES_DEFAULT = {"line-length": 110}
 
 
 # Default value of the field path 'Checks codespell config arguments'
-CODESPELL_ARGUMENTS_DEFAULT = ["--quiet-level=2", "--check-filenames"]
+CODESPELL_ARGUMENTS_DEFAULT = ["--quiet-level=2", "--check-filenames", "--ignore-words-list=ro"]
+
+
+# Default value of the field path 'Checks codespell config internal_dictionaries'
+CODESPELL_DICTIONARIES_DEFAULT = ["clear", "rare", "informal", "code", "names", "en-GB_to_en-US"]
 
 
 # Default value of the field path 'Checks codespell config ignore_re'
@@ -243,6 +247,18 @@ ChecksCodespell = Union["ChecksCodespellConfig", bool]
 ChecksCodespellConfig = TypedDict(
     "ChecksCodespellConfig",
     {
+        # codespell dictionaries
+        #
+        # List of argument that will be added to the codespell command
+        #
+        # default:
+        #   - clear
+        #   - rare
+        #   - informal
+        #   - code
+        #   - names
+        #   - en-GB_to_en-US
+        "internal_dictionaries": List[str],
         # codespell arguments
         #
         # List of argument that will be added to the codespell command
@@ -250,6 +266,7 @@ ChecksCodespellConfig = TypedDict(
         # default:
         #   - --quiet-level=2
         #   - --check-filenames
+        #   - --ignore-words-list=ro
         "arguments": List[str],
         # codespell ignore regular expression
         #

--- a/c2cciutils/prettier.py
+++ b/c2cciutils/prettier.py
@@ -127,7 +127,7 @@ class Prettier:
 
     def __enter__(self) -> PrettierModule:
         """
-        Initialise.
+        Initialize.
         """
         with open(os.path.join(os.path.dirname(__file__), "prettier.js"), encoding="utf-8") as query_open:
             javascript = query_open.read()

--- a/c2cciutils/schema.json
+++ b/c2cciutils/schema.json
@@ -195,10 +195,17 @@
           "description": "The codespell check configuration",
           "type": "object",
           "properties": {
+            "internal_dictionaries": {
+              "title": "codespell dictionaries",
+              "description": "List of argument that will be added to the codespell command",
+              "default": ["clear", "rare", "informal", "code", "names", "en-GB_to_en-US"],
+              "type": "array",
+              "items": { "type": "string" }
+            },
             "arguments": {
               "title": "codespell arguments",
               "description": "List of argument that will be added to the codespell command",
-              "default": ["--quiet-level=2", "--check-filenames"],
+              "default": ["--quiet-level=2", "--check-filenames", "--ignore-words-list=ro"],
               "type": "array",
               "items": { "type": "string" }
             },

--- a/c2cciutils/scripts/k8s/db.py
+++ b/c2cciutils/scripts/k8s/db.py
@@ -29,7 +29,7 @@ def main() -> None:
     password: mySuperTestingPassword
     database name: postgres""",
     )
-    parser.add_argument("--script", help="The script used to initialise the database")
+    parser.add_argument("--script", help="The script used to initialize the database")
     parser.add_argument("--cleanup", action="store_true", help="Drop the database")
 
     config = c2cciutils.get_config()

--- a/example-project/LICENSE.txt
+++ b/example-project/LICENSE.txt
@@ -1,4 +1,4 @@
-All the code in this library is provided under this licence:
+All the code in this library is provided under this license:
 
     Copyright (c) 2020, Camptocamp SA
     All rights reserved.


### PR DESCRIPTION
The new version generates many errors with the common use `ro`, then ignore it definitively.

Also add some other dictionary.