### PR TITLE
Add tag on the monitored image and app vuln check

### DIFF
--- a/c2cciutils/scripts/publish.py
+++ b/c2cciutils/scripts/publish.py
@@ -272,7 +272,18 @@ def main() -> None:
         snyk_exec, env = c2cciutils.snyk_exec()
         for image in images_full:
             if version_type in ("version_branch", "version_tag"):
-                subprocess.run([snyk_exec, "container", "monitor", image], check=True, env=env)
+                subprocess.run(
+                    [
+                        snyk_exec,
+                        "container",
+                        "monitor",
+                        f"--project-tags={image.split(':')[-1]}",
+                        image,
+                        "--app-vulns",
+                    ],
+                    check=True,
+                    env=env,
+                )
             # Currently just for information
             subprocess.run(  # pylint: disable=subprocess-run-check
                 [snyk_exec, "container", "test", "--app-vulns", "--severity-threshold=high", image], env=env


### PR DESCRIPTION
 --app-vulns
    Allow detection of vulnerabilities in your application dependencies from container images, as
    well as from the operating system, all in one single scan.

    In CLI version 1.962.0 and higher, use the --app-vulns option with the the --json option to see
    the operating system as well as application vulnerabilities in JSON format in the results.

    For more information see Detecting application vulnerabilities in container images https://docs.
    snyk.io/products/snyk-container/getting-around-the-snyk-container-ui/detecting-application-vulne
    rabilities-in-container-images