### PR TITLE
Fix CVE

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -112,7 +112,7 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -1391,7 +1391,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "d59946584ee9382deefb2c0f87349ce4b594212b5eb8ccc8823a2f3ac1bce9fa"
+content-hash = "b60cfa9ac3fb0e2bd03905d854d0e371733481d107bf7213cfa7a3099bd013a2"
 
 [metadata.files]
 astroid = [
@@ -1444,8 +1444,8 @@ cachetools = [
     {file = "cachetools-5.2.0.tar.gz", hash = "sha256:6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
+    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
 ]
 cffi = [
     {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ dparse = "0.5.2"
 oauthlib = "3.2.2"
 protobuf = "3.20.3"
 cryptography = "38.0.4"
+certifi = "2022.12.7"
 
 [tool.poetry.dev-dependencies]
 prospector = { version = "1.7.7", extras = [


### PR DESCRIPTION
    Pin certifi@2022.6.15 to certifi@2022.12.7 to fix
    ✗ Insufficient Verification of Data Authenticity (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CERTIFI-3164749] in certifi@2022.6.15
      introduced by pipenv@2022.6.7 > certifi@2022.6.15 and 7 other path(s)