### PR TITLE
Fix CVE

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -145,7 +145,7 @@ redis = ["redis (>=3.3.6,<4.0.0)"]
 
 [[package]]
 name = "certifi"
-version = "2022.6.15.1"
+version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -1743,7 +1743,7 @@ publish = ["twine", "google-api-python-client", "google-auth-httplib2", "google-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "a5cb6e4f096154773c3ddef59cba4d31f7716d0b007eb2fec3a4aa4e9bd452ad"
+content-hash = "c32ba473a61fd6d3d10766e734b59ca69c23ad77d36fe85844440f8ec7ef778b"
 
 [metadata.files]
 astroid = [
@@ -1804,8 +1804,8 @@ cachy = [
     {file = "cachy-0.3.0.tar.gz", hash = "sha256:186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15.1-py3-none-any.whl", hash = "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0"},
-    {file = "certifi-2022.6.15.1.tar.gz", hash = "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"},
+    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
+    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
 ]
 cffi = [
     {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ poetry = { version = "1.2.1", optional = true }
 poetry-core = { version = "1.2.0", optional = true }
 protobuf = { version = "4.21.10", optional = true }
 cryptography = "38.0.4"
+certifi = "2022.12.7"
 
 [tool.poetry.extras]
 audit = ["pipenv"]


### PR DESCRIPTION
    Pin certifi@2022.6.15.1 to certifi@2022.12.7 to fix
    ✗ Insufficient Verification of Data Authenticity (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CERTIFI-3164749] in certifi@2022.6.15.1
      introduced by pipenv@2022.9.8 > certifi@2022.6.15.1 and 15 other path(s)