### PR TITLE
Fix CVE

### DIFF
--- a/example-project/requirements.txt
+++ b/example-project/requirements.txt
@@ -1,2 +1,3 @@
 poetry==1.2.2
 poetry-core>=1.1.0a7 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools==65.5.1


### PR DESCRIPTION
    Upgrade setuptools@59.6.0 to setuptools@65.5.1 to fix
    ✗ Regular Expression Denial of Service (ReDoS) (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3180412] in setuptools@59.6.0
      introduced by setuptools@59.6.0