### PR TITLE
Fix CVE

### DIFF
--- a/example-project/requirements.txt
+++ b/example-project/requirements.txt
@@ -1,1 +1,2 @@
 poetry==1.2.2
+setuptools==65.5.1


### PR DESCRIPTION
    Upgrade setuptools@59.6.0 to setuptools@65.5.1 to fix
    ✗ Regular Expression Denial of Service (ReDoS) (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3180412] in setuptools@59.6.0
      introduced by setuptools@59.6.0