### PR TITLE
Fix CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ pipenv = { version = "2022.9.24", optional = true }
 safety = "2.1.1"
 markdown-table = "2020.12.3"
 python-magic = "0.4.27"
-requests = "2.28.2"
+requests = "2.31.0"
 Markdown = "3.4.3"
 EditorConfig = { version = "0.12.3", optional = true }
 google-api-python-client = { version = "2.60.0", optional = true }


### PR DESCRIPTION
    Upgrade requests@2.28.2 to requests@2.31.0 to fix
    ✗ Information Exposure (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-REQUESTS-5595532] in requests@2.28.2
      introduced by requests@2.28.2 and 14 other path(s)