### PR TITLE
Fix CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ poetry-plugin-tweak-dependencies-version = { version = "1.0.0", optional = true 
 poetry = { version = "1.2.1", optional = true }
 poetry-core = { version = "1.2.0", optional = true }
 protobuf = { version = "4.21.12", optional = true }
-cryptography = "41.0.1"
+cryptography = "41.0.2"
 certifi = "2022.12.7"
 Pygments = "2.15.0"
 


### PR DESCRIPTION
    Upgrade cryptography@41.0.1 to cryptography@41.0.2 to fix
    ✗ Improper Certificate Validation (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-5777683] in cryptography@41.0.1
      introduced by cryptography@41.0.1 and 5 other path(s)