### PR TITLE
Fix CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ protobuf = { version = "4.21.12", optional = true }
 cryptography = "41.0.4"
 certifi = "2023.7.22"
 Pygments = "2.15.1"
-urllib3 = { version = "1.26.17", optional = true }
+urllib3 = { version = "1.26.18", optional = true }
 
 [tool.poetry.extras]
 audit = ["pipenv"]


### PR DESCRIPTION
    Upgrade urllib3@1.26.17 to urllib3@1.26.18 to fix
    ✗ Information Exposure Through Sent Data (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-URLLIB3-6002459] in urllib3@1.26.17
      introduced by urllib3@1.26.17 and 22 other path(s)