### PR TITLE
Add a tool to update the dpkg-versions

### DIFF
--- a/c2cciutils/scripts/docker_versions_update.py
+++ b/c2cciutils/scripts/docker_versions_update.py
@@ -1,0 +1,97 @@
+import argparse
+import re
+import subprocess  # nosec
+import tempfile
+
+import ruamel.yaml
+
+import c2cciutils
+
+
+def main() -> None:
+    """Update the version of packages in the file ci/dpkg-versions.yaml."""
+
+    argparser = argparse.ArgumentParser(
+        description="Update the version of packages in the file ci/dpkg-versions.yaml."
+    )
+    argparser.add_argument("--branch", help="The branch to audit, not defined means autodetect")
+    args = argparser.parse_args()
+
+    cache: dict[str, dict[str, str]] = {}
+    yaml = ruamel.yaml.YAML()  # default_flow_style=False)
+    with open("ci/dpkg-versions.yaml", encoding="utf-8") as versions_file:
+        versions_config = yaml.load(versions_file)
+        for versions in versions_config.values():
+            for package_full in versions.keys():
+                dist, package = package_full.split("/")
+                if dist not in cache:
+                    correspondence = {
+                        "ubuntu_22_04": ("22.04", "jammy"),
+                    }
+                    if dist in correspondence:
+                        tag, dist_name = correspondence[dist]
+                        subprocess.run(
+                            ["docker", "rm", "--force", "apt"], stderr=subprocess.DEVNULL, check=False
+                        )
+                        subprocess.run(
+                            [
+                                "docker",
+                                "run",
+                                "--tty",
+                                "--interactive",
+                                "--detach",
+                                "--name=apt",
+                                "--entrypoint=",
+                                f"ubuntu:{tag}",
+                                "tail",
+                                "--follow",
+                                "/dev/null",
+                            ],
+                            check=True,
+                        )
+                        # Create a temporary file
+                        with tempfile.NamedTemporaryFile(mode="w", encoding=("utf-8")) as sources_list:
+                            sources_list.write(
+                                "\n".join(
+                                    [
+                                        f"deb http://archive.ubuntu.com/ubuntu/ {dist_name}-security main restricted",
+                                        f"deb http://archive.ubuntu.com/ubuntu/ {dist_name}-security universe",
+                                        f"deb http://archive.ubuntu.com/ubuntu/ {dist_name}-security multiverse",
+                                        "",
+                                    ]
+                                )
+                            )
+                            sources_list.flush()
+                            subprocess.run(
+                                ["docker", "cp", sources_list.name, "apt:/etc/apt/sources.list"], check=True
+                            )
+
+                        subprocess.run(["docker", "exec", "apt", "apt-get", "update"], check=True)
+
+                        package_re = re.compile(r"^([^ /]+)/[a-z-,]+ ([^ ]+) (all|amd64)( .*)?$")
+                        proc = subprocess.run(
+                            ["docker", "exec", "apt", "apt", "list"], check=True, stdout=subprocess.PIPE
+                        )
+                        for proc_line in proc.stdout.decode("utf-8").split("\n"):
+                            package_match = package_re.match(proc_line)
+                            if package_match is None:
+                                print(f"not matching: {proc_line}")
+                                continue
+                            cache.setdefault(dist, {})[package_match.group(1)] = package_match.group(2)
+
+                        subprocess.run(["docker", "rm", "--force", "apt"], check=True)
+
+                if package in cache[dist]:
+                    versions[package_full] = cache[dist][package]
+
+    with open("ci/dpkg-versions.yaml", "w", encoding="utf-8") as versions_file:
+        yaml.dump(versions_config, versions_file)
+
+    current_branch = c2cciutils.get_branch(args.branch)
+    c2cciutils.create_pull_request_if_needed(
+        current_branch, f"dpkg-update/{current_branch}", "Update dpkg package versions"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ c2cciutils-docker-logs = "c2cciutils.scripts.docker_logs:main"
 c2cciutils-trigger-image-update = "c2cciutils.scripts.trigger_image_update:main"
 c2cciutils-download-applications = "c2cciutils.scripts.download_applications:main"
 c2cciutils-docker-versions-gen = "c2cciutils.scripts.docker_versions_gen:main"
+c2cciutils-docker-versions-update = "c2cciutils.scripts.docker_versions_update:main"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Currently, we use Renovate to update the package, but they're a solution with some issues:
- This means that we add many packages to me managed by Renovate and it looks that Renovate and Repology didn't like that
- Repology has a structure that links the package of the same tool through all the distributions that makes it difficult to have the right packages names.

Then I write a small tool to update the version, the idea is to put it in the audit workflow.