### PR TITLE
Fix CVE

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -670,14 +670,14 @@ pyparsing = {version = ">=2.4.2,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.0.2 || >3.0
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
+    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
 ]
 
 [[package]]
@@ -2243,4 +2243,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "dc809c1bfc83195cbaede98d196ccce35a6da0e7b219c21d8a10eceb162e402d"
+content-hash = "de6fd1dbb71c2d7c18f48a0fe544472cb8fe060ee794696c1f2a3ef5719cfbe5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ pyyaml = "6.0.1"
 wheel = "0.38.4"
 pygments = "2.15.1"
 urllib3 = "1.26.18"
+idna = { version = "3.7", optional = true }
 
 [tool.poetry.dev-dependencies]
 prospector = { version = "1.9.0", extras = [


### PR DESCRIPTION
    Pin idna@3.3 to idna@3.7 to fix
    ✗ Resource Exhaustion (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-IDNA-6597975] in idna@3.3
      introduced by requests@2.31.0 > idna@3.3 and 6 other path(s)