### PR TITLE
Pin mheap/json-schema-spell-checker to version v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,7 +136,7 @@ repos:
         additional_dependencies:
           - prospector-profile-utils==1.27.0 # pypi
   - repo: https://github.com/mheap/json-schema-spell-checker
-    rev: main
+    rev: v2.3.0
     hooks:
       - id: json-schema-spell-checker
         files: |-


### PR DESCRIPTION
Pin the pre-commit hook `mheap/json-schema-spell-checker` from `main` to the tagged release `v2.3.0` for reproducible checks.