### PR TITLE
Pin mheap/json-schema-spell-checker to version v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,11 +133,15 @@ repos:
     rev: v2.3.0
     hooks:
       - id: json-schema-spell-checker
-        files: |-
-          (?x)^(
-            c2cciutils/schema\.json
-            |c2cciutils/schema\-applications\.json
-          )$
+        files: ^c2cciutils/schema\.json$
+        args:
+          - --fields=description
+          - --spelling=.github/spell-ignore-words.txt
+          - --ignore-numbers
+          - --ignore-acronyms
+          - --en-us
+      - id: json-schema-spell-checker
+        files: ^c2cciutils/schema\-applications\.json$
         args:
           - --fields=description
           - --spelling=.github/spell-ignore-words.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,7 +130,7 @@ repos:
           - prospector-profile-duplicated==1.6.0 # pypi
           - prospector-profile-utils==1.9.1 # pypi
   - repo: https://github.com/mheap/json-schema-spell-checker
-    rev: main
+    rev: v2.3.0
     hooks:
       - id: json-schema-spell-checker
         files: |-


### PR DESCRIPTION
Pin the pre-commit hook `mheap/json-schema-spell-checker` from `main` to the tagged release `v2.3.0` for reproducible checks.