### PR TITLE
Pin mheap/json-schema-spell-checker to version v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,11 +139,15 @@ repos:
     rev: v2.3.0
     hooks:
       - id: json-schema-spell-checker
-        files: |-
-          (?x)^(
-            c2cciutils/schema\.json
-            |c2cciutils/schema\-applications\.json
-          )$
+        files: ^c2cciutils/schema\.json$
+        args:
+          - --fields=description
+          - --spelling=.github/spell-ignore-words.txt
+          - --ignore-numbers
+          - --ignore-acronyms
+          - --en-us
+      - id: json-schema-spell-checker
+        files: ^c2cciutils/schema\-applications\.json$
         args:
           - --fields=description
           - --spelling=.github/spell-ignore-words.txt


### PR DESCRIPTION
Pin the pre-commit hook `mheap/json-schema-spell-checker` from `main` to the tagged release `v2.3.0` for reproducible checks.\n\nAlso split into two separate hook entries because v2.3.0 only accepts one source file per invocation.